### PR TITLE
fix number of expected arguments for STORE

### DIFF
--- a/src/main/java/tum/i2/cma/CMaInstructionType.java
+++ b/src/main/java/tum/i2/cma/CMaInstructionType.java
@@ -60,7 +60,6 @@ public enum CMaInstructionType {
         switch (type) {
             case LOADC:
             case LOAD:
-            case STORE:
             case LOADA:
             case STOREA:
             case JUMP:


### PR DESCRIPTION
We defined STORE as 

> writes the contents of the second topmost stack cell into the cell, whose
address in on top of the stack, and leaves the written value on top of the stack.

But the instruction itself does not take any arguments.